### PR TITLE
Co2 estimate integration

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -6,9 +6,9 @@
  # Licensed under the Apache License, Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.
  # You may obtain a copy of the License at
- #
+ 
  #      http://www.apache.org/licenses/LICENSE-2.0
- #
+ 
  # Unless required by applicable law or agreed to in writing, software
  # distributed under the License is distributed on an "AS IS" BASIS,
  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -44,6 +44,7 @@ function copy_files () {
   cp "../src/sls_strings.js" "sls_strings.js"
   cp "../src/sls_psi_api_connector.js" "sls_psi_api_connector.js"
   cp "../src/sls_reporting.js" "sls_reporting.js"
+  cp "../src/co2.js" "co2.js"
   cp "../src/sls_$audit_type.js" "sls_$audit_type.js"
 
   echo "Files successfully copied to output folder"

--- a/src/co2.js
+++ b/src/co2.js
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+/**
+ * Environment-wide variable that will be overridden by the IIFE import.
+ */
+let co2Library;
+
+/**
+ * Imports the co2 library using eval().
+ *
+ * Note: eval() is a security risk, only used due to AS limitations.
+ */
+function importCo2Library() {
+  if (typeof co2Library !== 'undefined') return;
+  try {
+    eval(UrlFetchApp.fetch('https://cdn.jsdelivr.net/npm/@tgwf/co2@latest/dist/iife/index.js').getContentText());
+    co2Library = co2;
+  } catch (error) {
+    Logger.log(error);
+  }
+}
+
+/**
+ * Checks whether the given URL is hosted on a green hosting provider.
+ *
+ * @param {string} url The URL to check.
+ * @returns {boolean} True if the URL is hosted on a green hosting provider, false otherwise.
+ */
+function checkGreenHosting(url) {
+  if (typeof co2Library === 'undefined') {
+    importCo2Library();
+  }
+  const hostname = url.split('/')[2];
+  const responseRaw = UrlFetchApp.fetch(`https://api.thegreenwebfoundation.org/greencheck/${hostname}`);
+  const response = JSON.parse(responseRaw);
+  return response.green;
+}
+
+/**
+ * Calculates the CO2eq per byte for the given number of bytes and URL.
+ *
+ * @param {number} totalBytes The total number of bytes.
+ * @param {string} [url] The URL to check. If specified, the calculation will take into account whether the URL is hosted on a green hosting provider.
+ * @returns {number} Estimated grams of CO2eq per byte.
+ */
+function getCo2eqPerByte(totalBytes, url = '') {
+  if (typeof co2Library === 'undefined') {
+    importCo2Library();
+  }
+  //If the URL is specified, we check whether TGWF has data on type
+  let isGreenHosting = false;
+  if (typeof url !== 'undefined') {
+    isGreenHosting = checkGreenHosting(url);
+  }
+  //Then we proceed with the calculation
+  const co2Calculation = new co2Library.co2();
+  return co2Calculation.perByte(totalBytes, isGreenHosting);
+}

--- a/src/co2.js
+++ b/src/co2.js
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+/* exported getCo2eqPerByte */
 
 /**
  * Environment-wide variable that will be overridden by the IIFE import.
@@ -29,7 +30,11 @@ let co2Library;
 function importCo2Library() {
   if (typeof co2Library !== 'undefined') return;
   try {
-    eval(UrlFetchApp.fetch('https://cdn.jsdelivr.net/npm/@tgwf/co2@latest/dist/iife/index.js').getContentText());
+    eval(
+        UrlFetchApp
+            .fetch(
+                'https://cdn.jsdelivr.net/npm/@tgwf/co2@latest/dist/iife/index.js')
+            .getContentText());
     co2Library = co2;
   } catch (error) {
     Logger.log(error);
@@ -40,14 +45,16 @@ function importCo2Library() {
  * Checks whether the given URL is hosted on a green hosting provider.
  *
  * @param {string} url The URL to check.
- * @returns {boolean} True if the URL is hosted on a green hosting provider, false otherwise.
+ * @return {boolean} True if the URL is hosted on a green hosting provider,
+ *     false otherwise.
  */
 function checkGreenHosting(url) {
   if (typeof co2Library === 'undefined') {
     importCo2Library();
   }
   const hostname = url.split('/')[2];
-  const responseRaw = UrlFetchApp.fetch(`https://api.thegreenwebfoundation.org/greencheck/${hostname}`);
+  const responseRaw = UrlFetchApp.fetch(
+      `https://api.thegreenwebfoundation.org/greencheck/${hostname}`);
   const response = JSON.parse(responseRaw);
   return response.green;
 }
@@ -56,19 +63,20 @@ function checkGreenHosting(url) {
  * Calculates the CO2eq per byte for the given number of bytes and URL.
  *
  * @param {number} totalBytes The total number of bytes.
- * @param {string} [url] The URL to check. If specified, the calculation will take into account whether the URL is hosted on a green hosting provider.
- * @returns {number} Estimated grams of CO2eq per byte.
+ * @param {string} [url] The URL to check. If specified, the calculation will
+ *     take into account whether the URL is hosted on a green hosting provider.
+ * @return {number} Estimated grams of CO2eq per byte.
  */
 function getCo2eqPerByte(totalBytes, url = '') {
   if (typeof co2Library === 'undefined') {
     importCo2Library();
   }
-  //If the URL is specified, we check whether TGWF has data on type
+  // If the URL is specified, we check whether TGWF has data on type
   let isGreenHosting = false;
   if (typeof url !== 'undefined') {
     isGreenHosting = checkGreenHosting(url);
   }
-  //Then we proceed with the calculation
-  const co2Calculation = new co2Library.co2();
+  // Then we proceed with the calculation
+  const co2Calculation = new co2Library.co2(); // eslint-disable-line new-cap
   return co2Calculation.perByte(totalBytes, isGreenHosting);
 }

--- a/src/sls_psi_api_connector.js
+++ b/src/sls_psi_api_connector.js
@@ -213,7 +213,7 @@ function parseResults(content, responseMap) {
     version,
   ];
 
-  // Added CO2eq measurement integrations behind a flag for backwards compatibility
+  // CO2eq measurement integrations behind a flag for backwards compatibility
   const documentProperties = PropertiesService.getDocumentProperties();
   const shouldIncludeCo2 = documentProperties.getProperty('INCLUDE_CO2EQ');
   if (shouldIncludeCo2) {


### PR DESCRIPTION
Includes the external library [co2.js](https://github.com/thegreenwebfoundation/co2.js) from The Green Web Foundation to be able to provide Katalyst performance audits with CO2eq estimates. This library is also used by many other common calculators and performance tooling such as WebPageTest.