### PR TITLE
Allow for adding entire extra decks, instead of slides by id

### DIFF
--- a/src/sls_core.js
+++ b/src/sls_core.js
@@ -51,7 +51,7 @@
 
 
 // Document properties
-const documentProperties = PropertiesService.getDocumentProperties();
+let documentProperties = PropertiesService.getDocumentProperties();
 
 // --- Katalyst loops
 
@@ -91,7 +91,6 @@ function createDeckFromDatasources() {
   }
 
   applyCustomStyle(newDeckId);
-  recordDeckCreated(newDeckId);
 }
 
 /**
@@ -400,7 +399,7 @@ function addInsightSlides(deck, insightDeck, row) {
       let insightDeckToUse;
       let insightSlideIds;
       if (isPresentationId(insights[0])) {
-        insightDeckToUse = SlidesApp.openById(insightID);
+        insightDeckToUse = SlidesApp.openById(insights[0]);
         insightSlideIds = insightDeckToUse.getSlides().map((item) => item.getObjectId())
       } else {
         insightDeckToUse = insightDeck;

--- a/src/sls_core.js
+++ b/src/sls_core.js
@@ -51,7 +51,7 @@
 
 
 // Document properties
-let documentProperties = PropertiesService.getDocumentProperties();
+const documentProperties = PropertiesService.getDocumentProperties();
 
 // --- Katalyst loops
 
@@ -400,7 +400,8 @@ function addInsightSlides(deck, insightDeck, row) {
       let insightSlideIds;
       if (isPresentationId(insights[0])) {
         insightDeckToUse = SlidesApp.openById(insights[0]);
-        insightSlideIds = insightDeckToUse.getSlides().map((item) => item.getObjectId())
+        insightSlideIds = insightDeckToUse.getSlides()
+            .map((item) => item.getObjectId());
       } else {
         insightDeckToUse = insightDeck;
         insightSlideIds = insights;

--- a/src/sls_core.js
+++ b/src/sls_core.js
@@ -380,6 +380,8 @@ function parseFieldsAndCreateCollectionSlide(deck, slideLayout, row) {
 
 /**
  * Adds a set of slides by id based on a provided external deck id.
+ * It can support both adding slides by ID from a specified deck at
+ * configuration level, or adding ALL slides from a variable insight deck.
  * @param {!GoogleAppsScript.Slides.Presentation} deck - The slide deck to add
  *     the slide to.
  * @param {!GoogleAppsScript.Slides.Presentation} insightDeck - The slide deck
@@ -395,7 +397,16 @@ function addInsightSlides(deck, insightDeck, row) {
     const insights =
         row[insightSlidesColumn - 1].split(',').map((item) => item.trim());
     if (insights.length > 0) {
-      appendInsightSlides(deck, insightDeck, insights);
+      let insightDeckToUse;
+      let insightSlideIds;
+      if (isPresentationId(insights[0])) {
+        insightDeckToUse = SlidesApp.openById(insightID);
+        insightSlideIds = insightDeckToUse.getSlides().map((item) => item.getObjectId())
+      } else {
+        insightDeckToUse = insightDeck;
+        insightSlideIds = insights;
+      }
+      appendInsightSlides(deck, insightDeckToUse, insightSlideIds);
     }
   }
 }

--- a/src/sls_facades.js
+++ b/src/sls_facades.js
@@ -54,7 +54,7 @@ function replaceSlideShapeWithSheetsChart(
   const chartHeight = slideChartShape.getInherentHeight();
   const chartWidth = slideChartShape.getInherentWidth();
   const chartTransform = slideChartShape.getTransform();
-  const presentationChartId = 'chart-test';
+  const presentationChartId = new Date().toDateString();  // This ID isn't used
   const requests = [
     {
       createSheetsChart: {
@@ -239,7 +239,7 @@ function addTextToPlaceholder(slide, placeholderType, text, defaultValue) {
  */
 function retrieveImageFromFolder(folder, imageName) {
   const searchQuery = `title contains '${imageName}'
-  and mimeType contains 'image'`;
+and mimeType contains 'image'`;
   const files = folder.searchFiles(searchQuery);
   let file = null;
 
@@ -297,8 +297,8 @@ function getImageValue(rawValue) {
     imageValue = decodeBase64Image(imageValue);
   } else if (!isValidImageUrl(imageValue)) {
     const folder = DriveApp.getFileById(SpreadsheetApp.getActive().getId())
-        .getParents()
-        .next();
+                       .getParents()
+                       .next();
     imageValue = retrieveImageFromFolder(folder, imageValue);
   }
   return imageValue;
@@ -386,7 +386,7 @@ function shouldCreateCollectionSlide() {
   const subtitleColumn = documentProperties.getProperty('SUBTITLE_COLUMN');
   const bodyColumn = documentProperties.getProperty('BODY_COLUMN');
   return (
-    (titleColumn && titleColumn.length > 0) ||
+      (titleColumn && titleColumn.length > 0) ||
       (subtitleColumn && subtitleColumn.length > 0) ||
       (bodyColumn && bodyColumn.length > 0));
 }
@@ -395,12 +395,13 @@ function shouldCreateCollectionSlide() {
  * Checks whether the provided ID is a valid presentation ID.
  *
  * @param {string} deckId The ID of the presentation to check.
- * @returns {boolean} True if the ID is a valid presentation ID, false otherwise.
+ * @returns {boolean} True if the ID is a valid presentation ID, false
+ *     otherwise.
  */
 function isPresentationId(deckId) {
   try {
     const file = DriveApp.getFileById(deckId);
-    if (file.getMimeType() === "application/vnd.google-apps.presentation") {
+    if (file.getMimeType() === 'application/vnd.google-apps.presentation') {
       return true;
     } else {
       return false;

--- a/src/sls_facades.js
+++ b/src/sls_facades.js
@@ -31,6 +31,7 @@
 /* exported filterAndSortData */
 /* exported colorForCWV */
 /* exported getImageValue */
+/* exported isPresentationId */
 
 /*
 Global redefined here to prevent access errors from the tests.
@@ -54,7 +55,7 @@ function replaceSlideShapeWithSheetsChart(
   const chartHeight = slideChartShape.getInherentHeight();
   const chartWidth = slideChartShape.getInherentWidth();
   const chartTransform = slideChartShape.getTransform();
-  const presentationChartId = new Date().toDateString();  // This ID isn't used
+  const presentationChartId = new Date().toDateString(); // This ID isn't used
   const requests = [
     {
       createSheetsChart: {
@@ -297,8 +298,8 @@ function getImageValue(rawValue) {
     imageValue = decodeBase64Image(imageValue);
   } else if (!isValidImageUrl(imageValue)) {
     const folder = DriveApp.getFileById(SpreadsheetApp.getActive().getId())
-                       .getParents()
-                       .next();
+        .getParents()
+        .next();
     imageValue = retrieveImageFromFolder(folder, imageValue);
   }
   return imageValue;
@@ -386,7 +387,7 @@ function shouldCreateCollectionSlide() {
   const subtitleColumn = documentProperties.getProperty('SUBTITLE_COLUMN');
   const bodyColumn = documentProperties.getProperty('BODY_COLUMN');
   return (
-      (titleColumn && titleColumn.length > 0) ||
+    (titleColumn && titleColumn.length > 0) ||
       (subtitleColumn && subtitleColumn.length > 0) ||
       (bodyColumn && bodyColumn.length > 0));
 }
@@ -395,7 +396,7 @@ function shouldCreateCollectionSlide() {
  * Checks whether the provided ID is a valid presentation ID.
  *
  * @param {string} deckId The ID of the presentation to check.
- * @returns {boolean} True if the ID is a valid presentation ID, false
+ * @return {boolean} True if the ID is a valid presentation ID, false
  *     otherwise.
  */
 function isPresentationId(deckId) {

--- a/src/sls_facades.js
+++ b/src/sls_facades.js
@@ -392,6 +392,26 @@ function shouldCreateCollectionSlide() {
 }
 
 /**
+ * Checks whether the provided ID is a valid presentation ID.
+ *
+ * @param {string} deckId The ID of the presentation to check.
+ * @returns {boolean} True if the ID is a valid presentation ID, false otherwise.
+ */
+function isPresentationId(deckId) {
+  try {
+    const file = DriveApp.getFileById(deckId);
+    if (file.getMimeType() === "application/vnd.google-apps.presentation") {
+      return true;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    return false;
+  }
+}
+
+
+/**
  * Appends insight slides by reference to the generated deck
  *
  * @param {!Presentation} deck Reference to the generated deck


### PR DESCRIPTION
Previously, only extra slides could be added into a created deck (after creation). This modification allows for either integrating **one** entire deck, found by id, or a comma separated list of slides from a config-level defined deck.